### PR TITLE
curltests name added

### DIFF
--- a/.github/workflows/curltests.yml
+++ b/.github/workflows/curltests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   docker-compose-curltests:
     runs-on: ubuntu-latest
+    name: Run API tests with Docker
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently, we can merge any pull request into the `main` branch even if some tests are failed. To add the check to the ruleset, we should give it a name.