### PR TITLE
Move RUN npm install to the beginning of the dockerfiles in /frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@ FROM node:24-alpine
 RUN mkdir /app
 WORKDIR /app
 COPY package.json package-lock.json .
+RUN npm install
 RUN mkdir public && mkdir src
 COPY public public
 COPY src src
-RUN npm install
 CMD ["npm", "start"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,10 +2,11 @@ FROM node:24-alpine AS code
 RUN mkdir /app
 WORKDIR /app
 COPY package.json package-lock.json .
+RUN npm install
 RUN mkdir public && mkdir src
 COPY public public
 COPY src src
-RUN npm install && npm run build
+RUN npm run build
 
 FROM node:24-alpine
 RUN npm install -g serve && mkdir /app


### PR DESCRIPTION
This makes `docker compose up --build` faster if the node packages haven't changed